### PR TITLE
Remove vcs clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 <h1 align="center">terraform-workspace-clone 👋</h1>
+
+
+> A NPM global module to clone terraform workspace.
 <p>
   <img alt="Version" src="https://img.shields.io/badge/version-1.0.0-blue.svg" />
   <img alt="Version" src="https://img.shields.io/badge/license-MIT-orange.svg" />
 </p>
 
-# ✨
+# Getting started
 > Clone existing terraform workspace.
 
 ### 🏠 [Homepage](https://github.com/Sachin1678/terraform-workspace-clone#readme)
@@ -32,6 +35,9 @@ terraform-workspace-clone
 npm run test
 ```
 
+## New planned features
+* Clone across multiple domains.
+* Allow config file path also for the required details.
 ## Author
 
 👤 **Sachin <rajput.sachingla@gmail.com>**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "terraform-workspace-clone",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Sachin<rajput.sachingla@gmail.com>",
   "license": "MIT",
   "scripts": {

--- a/src/core/clone.ts
+++ b/src/core/clone.ts
@@ -75,11 +75,6 @@ export default class TFCloneWS {
           'terraform-version': workspaceData.attributes['terraform-version'],
           'working-directory': workspaceData.attributes['working-directory'],
           'tag-names': workspaceData.attributes['tag-names'],
-          'vcs-repo': _.pick(workspaceData.attributes['vcs-repo'], [
-            'identifier',
-            'branch',
-            'oauth-token-id',
-          ]),
         },
         type: 'workspaces',
       },


### PR DESCRIPTION
Vcs clone needs o-auth-token id which doesn't work across the terraform organisations so removing it for now.